### PR TITLE
CSS tweak for no overlap on snapshotDetails image bottom.

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -17,7 +17,6 @@ body {
   height: 60px;
 }
 
-
 /* Custom page CSS
 -------------------------------------------------- */
 /* Not required for template or sticky footer method. */
@@ -142,6 +141,7 @@ fieldset > * {
 .capture-details {
   width: 70%;
   float: left;
+  padding-bottom: 65px;
 }
 
 .fa-6 {


### PR DESCRIPTION
Closes #45 
